### PR TITLE
[#13] parsing xml fix - parsing CDATA and comments

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -117,14 +117,14 @@ export function xmlParse(xml) {
                 if (endTagIndex) {
                     let node = domCreateComment(xmldoc, xml.slice(i+4, i+endTagIndex+4));
                     domAppendChild(parent, node);
-                    i += endTagIndex+7;
+                    i += endTagIndex+6;
                 }
             } else if (xml.slice(i+1,i+9)==="![CDATA[") {
                 let endTagIndex = xml.slice(i+9).indexOf(']]>');
                 if (endTagIndex) {
                     let node = domCreateCDATASection(xmldoc, xml.slice(i+9, i+endTagIndex+9));
                     domAppendChild(parent, node);
-                    i += endTagIndex+12;
+                    i += endTagIndex+11;
                 }
             } else {
                 tag = true;


### PR DESCRIPTION
Example:
```xml
...
<testcase name="Variance_V1" status="run" time="0" classname="Covariances_Tests" />
<!--some comment--><testcase name="Covariance" status="run" time="0" classname="Covariances_Tests" />
...
```
In this case parser after processing comment skips char `<` and whole next `testcase` element is skipped in result. The same occurs while using CDATA:
```xml
...
<testcase name="Variance_V1" status="run" time="0" classname="Covariances_Tests" /><!CDATA[some data
]]>--><testcase name="Covariance" status="run" time="0" classname="Covariances_Tests" />
...
```

The problem is index `i` is incremented too much because for-loop increment it once more.
The solution is incrementing 1 down.