### PR TITLE
Export ExprContext so it an be used to parse xpath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export {xsltProcess} from "./xslt.js"
 export {xmlParse} from "./dom.js"
-export {xpathParse} from "./xpath.js"
+export {xpathParse, ExprContext} from "./xpath.js"


### PR DESCRIPTION
This constructor is required along with `xpathParse` in order to
parse XPath expressions in Node context.